### PR TITLE
Facebook events sync script

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,6 +27,7 @@ exclude:
   - bower.json
   - gulpfile.js
   - assets/bower_components
+  - facebook-sync
 
 # Collections
 

--- a/facebook-sync/index.js
+++ b/facebook-sync/index.js
@@ -1,0 +1,196 @@
+var fs = require("fs");
+var rp = require("request-promise");
+var glob = require("glob");
+var slug = require("slug");
+var frontMatter = require("front-matter");
+var yaml = require("js-yaml");
+var moment = require("moment");
+var _ = require("lodash");
+var Q = require("q");
+
+
+// Facebook API
+
+var ACCESS_TOKEN = "CAAK3kpvZBViIBABPZBbXkYpmpN1x8FQO5AdkwnRgVSdVGKY6JdpfNVJMvWMQHJRdFod0kO87FjGC2aPLJhf7P4JRUfKwF15ojU42SMoo9rGZBA3tucOBmimKSiDDX4jEjZBlkAQhFTzpRwIPpi1bYve9iZAwRXKodLK0Q6ujVKjTkj6wdAv4FJRvg8x7vPI8ZD";
+
+function getFacebookEvents() {
+  return rp({
+    uri: "https://graph.facebook.com/v2.5/UCLUTechSoc/events",
+    qs: {
+      access_token: ACCESS_TOKEN,
+      fields: [
+        "id",
+        "start_time",
+        "end_time",
+        "name",
+        "place",
+        "ticket_uri",
+        "description"
+      ].join(",")
+    },
+    json: true
+  }).then(function(response) {
+    return response.data.map(parseFacebookEvent);
+  });
+}
+
+
+// Facebook data transformation
+
+function parseTime(time) {
+  return moment(time).format("YYYY-MM-DD HH:mm");
+}
+
+function parseFacebookEvent(event) {
+
+  var output = {};
+  var attrs = output.attributes = {};
+
+  attrs.facebook_id = event.id;
+
+  if (event.name) {
+    // remove trailing exclamation mark
+    attrs.title = event.name.replace(/!$/, "");
+  }
+  if (event.start_time) {
+    attrs.start_time = parseTime(event.start_time);
+  }
+  if (event.end_time) {
+    attrs.end_time = parseTime(event.end_time);
+  }
+  if (event.place && event.place.name) {
+    attrs.location = event.place.name;
+  }
+  if (event.ticket_uri) {
+    attrs.actions = [{ label: "Get tickets", url: event.ticket_uri }];
+  }
+  if (event.description) {
+    output.body = "\n" + event.description;
+  }
+
+  return output;
+}
+
+
+// Local files
+
+function getSiteEvents() {
+  return new Promise(function(resolve, reject) {
+
+    glob("_events/*.md", function(err, filenames) {
+      if (err) return reject(err);
+      return resolve(filenames.map(getSiteEvent));
+    });
+
+  });
+}
+
+function getSiteEvent(filename) {
+  var fileContent = fs.readFileSync(filename, "utf8");
+  var output = frontMatter(fileContent);
+  return _.extend(output, { filename: filename });
+}
+
+function generateFileContent(event) {
+  var output = "";
+  output += "---\n";
+  output += yaml.dump(event.attributes);
+  output += "---\n";
+  output += event.body;
+  return output;
+}
+
+function saveEventFile(event) {
+  var title = event.attributes.title;
+  var content = generateFileContent(event);
+  var filename;
+
+  if (event.filename) {
+    filename = event.filename;
+  } else {
+    filename = "_events/import-" + slug(title, {lower: true}) + ".md";
+  }
+
+  console.log("Adding " + title + "...")
+  fs.writeFileSync(filename, content);
+}
+
+
+// Compare start & end times
+
+function findEvent(events, facebookEventId) {
+  return _.find(events, { attributes: { facebook_id: facebookEventId } });
+}
+
+function compareEvents(facebookEvent, siteEvent) {
+  var title = siteEvent.attributes.title;
+  var filename = siteEvent.filename;
+
+  var fb = facebookEvent.attributes;
+  var site = siteEvent.attributes;
+
+  if (fb.start_time != site.start_time) {
+    console.log("\n" + title + " (" + filename + ") has mismatching start time:");
+    console.log("  Facebook start time: " + fb.start_time);
+    console.log("      Site start time: " + site.start_time);
+  }
+
+  if (fb.end_time && fb.end_time != site.end_time) {
+    console.log("\n" + title + " (" + filename + ") has mismatching end time:");
+    console.log("  Facebook end time: " + fb.end_time);
+    console.log("      Site end time: " + site.end_time);
+  }
+}
+
+
+// LET'S GET IT STARTED
+
+Q.all([
+  getFacebookEvents(),
+  getSiteEvents()
+]).spread(function(facebookEvents, siteEvents) {
+
+  var facebookEventsIds = _.pluck(facebookEvents, "attributes.facebook_id");
+  var siteEventsIds     = _.pluck(siteEvents,     "attributes.facebook_id");
+
+  // Compare times for existing events
+
+  console.log("\nComparing start/end times for existing events...");
+
+  var existingFacebookIds = _.intersection(
+    facebookEventsIds,
+    siteEventsIds
+  );
+
+  existingFacebookIds.forEach(function(facebookEventId) {
+    var facebookEvent = findEvent(facebookEvents, facebookEventId);
+    var siteEvent     = findEvent(siteEvents,     facebookEventId);
+    compareEvents(facebookEvent, siteEvent);
+  })
+
+  // Add missing events
+
+  console.log("\nAdding missing events...");
+
+  var missingFacebookIds = _.difference(
+    facebookEventsIds,
+    siteEventsIds
+  );
+
+  var missingEvents = _.filter(facebookEvents, function(event) {
+    return _.contains(missingFacebookIds, event.attributes.facebook_id);
+  });
+
+  missingEvents.forEach(saveEventFile);
+
+  if (missingEvents.length > 0) {
+    console.log("\nPlease don't forget to rename the files!");
+    console.log("Add series_ids and project_ids where necessary, and review content before committing.");
+    console.log("\nThanks. TechSoc loves you <3");
+  } else {
+    console.log("No events to add, they are all synced up!");
+  }
+
+}).catch(function(err) {
+  console.error(err);
+});

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -78,6 +78,7 @@ gulp.task('sass', function() {
      '!assets/scss/**/*',
      '!node_modules/**/*',
      '!_site/**/*',
+     '!facebook-sync/**/*',
      '!*',
      '*.html',
      '*.yml',

--- a/package.json
+++ b/package.json
@@ -18,9 +18,18 @@
   "homepage": "https://github.com/techsoc/website-2015#readme",
   "devDependencies": {
     "browser-sync": "^2.9.11",
+    "front-matter": "^2.0.0",
+    "glob": "^6.0.1",
     "gulp": "^3.9.0",
     "gulp-autoprefixer": "^3.1.0",
     "gulp-sass": "^2.0.4",
-    "gulp-sourcemaps": "^1.6.0"
-  }
+    "gulp-sourcemaps": "^1.6.0",
+    "js-yaml": "^3.4.4",
+    "lodash": "^3.10.1",
+    "moment": "^2.10.6",
+    "q": "^1.4.1",
+    "request-promise": "^1.0.2",
+    "slug": "^0.9.1"
+  },
+  "dependencies": {}
 }


### PR DESCRIPTION
Since we were gonna have to do it at some point, the sooner it is, the better.

This messy node script does 2 things:

1. Adds events that are missing on the site, but already exist on Facebook
2. Compares the start and end times of events that have facebook IDs

To use, **cd** to the root project directory and install all dependencies by running:

```
npm install
```

Then to run the script:

```
node facebook-sync
```

Oh and let's try to stick to the top graph: https://xkcd.com/1319/